### PR TITLE
Always show social work item category

### DIFF
--- a/web/components/work-item-tile.js
+++ b/web/components/work-item-tile.js
@@ -18,6 +18,7 @@ const WorkItemTile = ({
   className,
   playLockupClassName,
   aspectRatio,
+  typographyClassNameOverrides = {},
 }) => {
   const [isHovered, setIsHovered] = useState(autoPlay)
   const [hasHovered, setHasHovered] = useState(autoPlay)
@@ -114,7 +115,7 @@ const WorkItemTile = ({
         {showWithPlayLockup ? (
           <div
             className={classNames(
-              'flex w-full items-center justify-start gap-4 pl-4 pr-2 text-left',
+              'flex w-full items-center justify-start gap-4 pr-2 pl-4 text-left',
               playLockupClassName
             )}
           >
@@ -123,7 +124,7 @@ const WorkItemTile = ({
                 <GrPlay className="size-10 py-2 pl-1" />
               </div>
             </div>
-            <div className="border-l-4 border-gold pl-4">
+            <div className="border-gold border-l-4 pl-4">
               <div className="text-xl font-bold uppercase">
                 {workItem.clientName}
               </div>
@@ -134,10 +135,25 @@ const WorkItemTile = ({
           </div>
         ) : (
           <>
-            <h2 className="text-3xl font-extrabold uppercase lg:text-2xl">
+            <h2
+              className={
+                typographyClassNameOverrides?.clientName
+                  ? typographyClassNameOverrides.clientName
+                  : classNames(
+                      'text-3xl font-extrabold uppercase',
+                      'lg:text-2xl'
+                    )
+              }
+            >
               {workItem.clientName}
             </h2>
-            <h3 className="font-outline text-3xl uppercase lg:text-2xl">
+            <h3
+              className={
+                typographyClassNameOverrides?.title
+                  ? typographyClassNameOverrides.title
+                  : classNames('font-outline text-3xl uppercase', 'lg:text-2xl')
+              }
+            >
               {workItem.title}
             </h3>
           </>

--- a/web/cspell.json
+++ b/web/cspell.json
@@ -43,6 +43,7 @@
     "uuidv",
     "viruserv",
     "webkitallowfullscreen",
-    "workfront"
+    "workfront",
+    "yarl"
   ]
 }

--- a/web/pages/work/index.js
+++ b/web/pages/work/index.js
@@ -148,6 +148,20 @@ function Work({ workPage, workItemCategories }) {
                       }
                     : undefined
                 }
+                typographyClassNameOverrides={
+                  isSocialLayout
+                    ? {
+                        clientName: classNames(
+                          'text-lg font-extrabold uppercase',
+                          'lg:text-2xl'
+                        ),
+                        title: classNames(
+                          'font-outline text-lg uppercase',
+                          'lg:text-2xl'
+                        ),
+                      }
+                    : undefined
+                }
               />
             )
           })}

--- a/web/pages/work/index.js
+++ b/web/pages/work/index.js
@@ -200,7 +200,7 @@ export async function getStaticProps() {
 
   const workItemCategories = await sanityClient.fetch(
     groq`
-      *[_type == "workItemCategory"][showOnWorkPage == true]|order(order asc){
+      *[_type == "workItemCategory"][showOnWorkPage == true || name == "Social"]|order(order asc){
         name,
         order,
         workItems[]->{
@@ -217,30 +217,6 @@ export async function getStaticProps() {
       }
   `
   )
-
-  const socialWorkItemCategory = await sanityClient.fetch(
-    groq`
-      *[_type == "workItemCategory"][name == "Social"][0]{
-        name,
-        order,
-        workItems[]->{
-          _id,
-          slug,
-          clientName,
-          title,
-          poster,
-          "shortClipMp4URL": shortClipMp4.asset->url,
-          "shortClipMp4S3URL": shortClipMp4S3.asset->fileURL,
-          "shortClipOgvURL": shortClipOgv.asset->url,
-          "shortClipOgvS3URL": shortClipOgvS3.asset->fileURL,
-        }
-      }
-  `
-  )
-
-  if (!workItemCategories.find((category) => category.name === 'Social')) {
-    workItemCategories.push(socialWorkItemCategory)
-  }
 
   return {
     props: {

--- a/web/pages/work/index.js
+++ b/web/pages/work/index.js
@@ -218,6 +218,30 @@ export async function getStaticProps() {
   `
   )
 
+  const socialWorkItemCategory = await sanityClient.fetch(
+    groq`
+      *[_type == "workItemCategory"][name == "Social"][0]{
+        name,
+        order,
+        workItems[]->{
+          _id,
+          slug,
+          clientName,
+          title,
+          poster,
+          "shortClipMp4URL": shortClipMp4.asset->url,
+          "shortClipMp4S3URL": shortClipMp4S3.asset->fileURL,
+          "shortClipOgvURL": shortClipOgv.asset->url,
+          "shortClipOgvS3URL": shortClipOgvS3.asset->fileURL,
+        }
+      }
+  `
+  )
+
+  if (!workItemCategories.find((category) => category.name === 'Social')) {
+    workItemCategories.push(socialWorkItemCategory)
+  }
+
   return {
     props: {
       workPage,


### PR DESCRIPTION
This is only temporary until we can go live with it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the Work page to always include and display the "Social" category.
  - Updated the appearance of work items in the "Social" tab with distinct typography styles for client names and titles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->