### PR TITLE
Round image corners and adjust work grid spacing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 
 .DS_Store
+web/next-env.d.ts

--- a/web/components/moments-gallery.js
+++ b/web/components/moments-gallery.js
@@ -94,7 +94,7 @@ const MomentsGallery = ({ images = [] }) => {
               >
                 <Image
                   alt={image.altText}
-                  className={`bpd-gallery-image cursor-pointer`}
+                  className={`bpd-gallery-image cursor-pointer rounded-xl`}
                   height={height}
                   onClick={() => {
                     setIsGalleryModelOpen(true)
@@ -125,7 +125,7 @@ const MomentsGallery = ({ images = [] }) => {
               <div className={clsx('bpd-gallery-image-container')} key={index}>
                 <Image
                   alt={image.altText}
-                  className={`bpd-gallery-image cursor-pointer`}
+                  className={`bpd-gallery-image cursor-pointer rounded-xl`}
                   height={height}
                   onClick={() => {
                     setIsGalleryModelOpen(true)

--- a/web/components/work-item-category.js
+++ b/web/components/work-item-category.js
@@ -91,93 +91,98 @@ export const WorkItemCategory = ({
             ? `${currentCategory.name} ${workPage.seoTitle}`
             : workPage.seoTitle}
         </h1>
-        <ul
-          className={clsx(
-            'mx-6 flex flex-wrap items-center justify-center gap-y-1 border-t py-4 font-semibold',
-            'lg:mx-8 lg:mt-4 lg:flex lg:flex-nowrap lg:divide-x lg:divide-white lg:pt-4',
-            'xl:mx-24',
-            '2xl:mx-48'
-          )}
-        >
-          {workItemCategories.map((tab, index) => {
-            return (
-              <li
-                className={clsx(
-                  'relative flex justify-center border-r text-xs',
-                  'last:border-r-0',
-                  'lg:px-4 lg:text-base'
-                )}
-                key={index}
-              >
-                <Link
-                  className={clsx(
-                    'rounded-xl border px-2 py-1 uppercase transition-all',
-                    'lg:tracking-wider',
-                    workItemCategory === defaultSlugify(tab.name)
-                      ? 'mx-2 border-white lg:px-4'
-                      : 'border-black hover:scale-110'
-                  )}
-                  href={
-                    index === 0
-                      ? '/work'
-                      : `/work/category/${defaultSlugify(tab.name)}`
-                  }
-                >
-                  {tab.name}
-
-                  <span className="absolute inset-0" />
-                </Link>
-              </li>
-            )
-          })}
-        </ul>
-        {/* lg:grid-cols-1 lg:grid-cols-2 lg:grid-cols-3 */}
         <div
           className={clsx(
-            'mx-4 mt-2 grid grid-cols-1 gap-4',
-            filteredWorkItems.length >= 3
-              ? 'lg:grid-cols-3'
-              : `lg:grid-cols-${filteredWorkItems.length}`,
-            isSocialLayout && 'mx-auto grid-cols-3 xl:grid-cols-6'
+            'container mx-auto mt-6 rounded-2xl bg-white p-4 text-black',
+            'lg:mt-12 lg:p-8'
           )}
         >
-          {filteredWorkItems.map((workItem, index) => {
-            return (
-              <WorkItemTile
-                workItem={workItem}
-                key={index}
-                aspectRatio={
-                  isSocialLayout
-                    ? `aspect-w-${workItem.videoWidthAspectRatio} aspect-h-${workItem.videoHeightAspectRatio}`
-                    : ''
-                }
-                onClick={
-                  isSocialLayout
-                    ? () => {
-                        setLightboxActiveIndex(index)
-                      }
-                    : undefined
-                }
-                typographyClassNameOverrides={
-                  isSocialLayout
-                    ? {
-                        clientName: clsx(
-                          'text-lg font-extrabold uppercase transition-opacity duration-300',
-                          'lg:text-2xl',
-                          'group-hover:opacity-0'
-                        ),
-                        title: clsx(
-                          'font-outline text-lg uppercase transition-opacity duration-300',
-                          'lg:text-2xl',
-                          'group-hover:opacity-0'
-                        ),
-                      }
-                    : undefined
-                }
-                showPlayOnHover={isSocialLayout}
-              />
-            )
-          })}
+          <ul
+            className={clsx(
+              'flex flex-wrap items-center justify-center gap-y-1 border-t border-black/10 py-4 font-semibold',
+              'lg:flex lg:flex-nowrap lg:divide-x lg:divide-black/20 lg:pt-4'
+            )}
+          >
+            {workItemCategories.map((tab, index) => {
+              return (
+                <li
+                  className={clsx(
+                    'relative flex justify-center border-r border-black/20 text-xs',
+                    'last:border-r-0',
+                    'lg:px-4 lg:text-base'
+                  )}
+                  key={index}
+                >
+                  <Link
+                    className={clsx(
+                      'rounded-xl border px-2 py-1 uppercase transition-all',
+                      'lg:tracking-wider',
+                      workItemCategory === defaultSlugify(tab.name)
+                        ? 'mx-2 border-black lg:px-4'
+                        : 'border-transparent hover:scale-110'
+                    )}
+                    href={
+                      index === 0
+                        ? '/work'
+                        : `/work/category/${defaultSlugify(tab.name)}`
+                    }
+                  >
+                    {tab.name}
+
+                    <span className="absolute inset-0" />
+                  </Link>
+                </li>
+              )
+            })}
+          </ul>
+          {/* lg:grid-cols-1 lg:grid-cols-2 lg:grid-cols-3 */}
+          <div
+            className={clsx(
+              'mt-4 grid grid-cols-1 gap-4',
+              filteredWorkItems.length >= 3
+                ? 'lg:grid-cols-3'
+                : `lg:grid-cols-${filteredWorkItems.length}`,
+              isSocialLayout && 'mx-auto grid-cols-3 xl:grid-cols-6'
+            )}
+          >
+            {filteredWorkItems.map((workItem, index) => {
+              return (
+                <WorkItemTile
+                  workItem={workItem}
+                  key={index}
+                  aspectRatio={
+                    isSocialLayout
+                      ? `aspect-w-${workItem.videoWidthAspectRatio} aspect-h-${workItem.videoHeightAspectRatio}`
+                      : ''
+                  }
+                  onClick={
+                    isSocialLayout
+                      ? () => {
+                          setLightboxActiveIndex(index)
+                        }
+                      : undefined
+                  }
+                  typographyClassNameOverrides={
+                    isSocialLayout
+                      ? {
+                          clientName: clsx(
+                            'text-lg font-extrabold uppercase transition-opacity duration-300',
+                            'lg:text-2xl',
+                            'group-hover:opacity-0'
+                          ),
+                          title: clsx(
+                            'font-outline text-lg uppercase transition-opacity duration-300',
+                            'lg:text-2xl',
+                            'group-hover:opacity-0'
+                          ),
+                        }
+                      : undefined
+                  }
+                  showPlayOnHover={isSocialLayout}
+                />
+              )
+            })}
+          </div>
         </div>
         {workPage.workPageDescription && (
           <div className="container mx-auto mt-12 px-12 text-center text-white">

--- a/web/components/work-item-category.js
+++ b/web/components/work-item-category.js
@@ -134,7 +134,7 @@ export const WorkItemCategory = ({
         {/* lg:grid-cols-1 lg:grid-cols-2 lg:grid-cols-3 */}
         <div
           className={clsx(
-            'mx-1 grid grid-cols-1 gap-1',
+            'mx-4 mt-2 grid grid-cols-1 gap-4',
             filteredWorkItems.length >= 3
               ? 'lg:grid-cols-3'
               : `lg:grid-cols-${filteredWorkItems.length}`,

--- a/web/components/work-item-category.js
+++ b/web/components/work-item-category.js
@@ -91,16 +91,11 @@ export const WorkItemCategory = ({
             ? `${currentCategory.name} ${workPage.seoTitle}`
             : workPage.seoTitle}
         </h1>
-        <div
-          className={clsx(
-            'container mx-auto mt-6 rounded-2xl bg-white p-4 text-black',
-            'lg:mt-12 lg:p-8'
-          )}
-        >
+        <div className="max-w-8xl mx-auto px-4 lg:px-8">
           <ul
             className={clsx(
-              'flex flex-wrap items-center justify-center gap-y-1 border-t border-black/10 py-4 font-semibold',
-              'lg:flex lg:flex-nowrap lg:divide-x lg:divide-black/20 lg:pt-4'
+              'mx-7 flex flex-wrap items-center justify-center gap-y-1 rounded-2xl bg-black/80 py-4 font-semibold',
+              'lg:sticky lg:top-4 lg:z-20 lg:flex lg:flex-nowrap lg:divide-x lg:divide-black/20 lg:shadow-xl lg:backdrop-blur-sm'
             )}
           >
             {workItemCategories.map((tab, index) => {
@@ -109,16 +104,16 @@ export const WorkItemCategory = ({
                   className={clsx(
                     'relative flex justify-center border-r border-black/20 text-xs',
                     'last:border-r-0',
-                    'lg:px-4 lg:text-base'
+                    'lg:px-2 lg:text-base'
                   )}
                   key={index}
                 >
                   <Link
                     className={clsx(
-                      'rounded-xl border px-2 py-1 uppercase transition-all',
+                      'rounded-xs border px-4 py-1 uppercase transition-all',
                       'lg:tracking-wider',
                       workItemCategory === defaultSlugify(tab.name)
-                        ? 'mx-2 border-black lg:px-4'
+                        ? 'border-white bg-black/30'
                         : 'border-transparent hover:scale-110'
                     )}
                     href={
@@ -135,146 +130,155 @@ export const WorkItemCategory = ({
               )
             })}
           </ul>
-          {/* lg:grid-cols-1 lg:grid-cols-2 lg:grid-cols-3 */}
-          <div
-            className={clsx(
-              'mt-4 grid grid-cols-1 gap-4',
-              filteredWorkItems.length >= 3
-                ? 'lg:grid-cols-3'
-                : `lg:grid-cols-${filteredWorkItems.length}`,
-              isSocialLayout && 'mx-auto grid-cols-3 xl:grid-cols-6'
-            )}
-          >
-            {filteredWorkItems.map((workItem, index) => {
-              return (
-                <WorkItemTile
-                  workItem={workItem}
-                  key={index}
-                  aspectRatio={
-                    isSocialLayout
-                      ? `aspect-w-${workItem.videoWidthAspectRatio} aspect-h-${workItem.videoHeightAspectRatio}`
-                      : ''
-                  }
-                  onClick={
-                    isSocialLayout
-                      ? () => {
-                          setLightboxActiveIndex(index)
-                        }
-                      : undefined
-                  }
-                  typographyClassNameOverrides={
-                    isSocialLayout
-                      ? {
-                          clientName: clsx(
-                            'text-lg font-extrabold uppercase transition-opacity duration-300',
-                            'lg:text-2xl',
-                            'group-hover:opacity-0'
-                          ),
-                          title: clsx(
-                            'font-outline text-lg uppercase transition-opacity duration-300',
-                            'lg:text-2xl',
-                            'group-hover:opacity-0'
-                          ),
-                        }
-                      : undefined
-                  }
-                  showPlayOnHover={isSocialLayout}
-                />
-              )
-            })}
-          </div>
-        </div>
-        {workPage.workPageDescription && (
-          <div className="container mx-auto mt-12 px-12 text-center text-white">
-            {workPage.workPageDescription && (
-              <div className="prose prose-lg prose-invert mx-auto max-w-lg border py-1 text-center">
-                <PortableText value={workPage.workPageDescription} />
-              </div>
-            )}
-          </div>
-        )}
-        {showWhiteContainer && (
-          <div
-            className={clsx(
-              'container mx-auto mt-2 rounded-2xl bg-white p-4 text-center text-black',
-              'lg:p-12'
-            )}
-          >
-            {currentCategory?.imageGallery &&
-              currentCategory.imageGallery.length > 0 && (
-                <ClientOnly>
-                  <ImageGallery images={currentCategory.imageGallery} />
-                </ClientOnly>
-              )}
-            {(currentCategory?.title ||
-              currentCategory?.subtitle ||
-              currentCategory?.body) && (
-              <div className="mt-12">
-                {currentCategory?.title && (
-                  <h2 className="text-3xl font-extrabold uppercase lg:text-3xl">
-                    {currentCategory.title}
-                  </h2>
-                )}
-                {currentCategory?.subtitle && (
-                  <h3 className="font-outline text-3xl uppercase lg:text-4xl">
-                    {currentCategory.subtitle}
-                  </h3>
-                )}
-                {currentCategory?.body && (
-                  <>
-                    <LittleBlackBar yMargin="my-6" maxWidth="max-w-xs" />
-                    <div className="mx-auto max-w-2xl py-1 text-center text-sm font-light uppercase">
-                      <PortableText value={currentCategory.body} />
-                    </div>
-                  </>
-                )}
-              </div>
-            )}
-          </div>
-        )}
-      </div>
 
-      {isSocialLayout && (
-        <Lightbox
-          open={lightboxActiveIndex !== null}
-          slides={lightboxSlides}
-          index={lightboxActiveIndex}
-          close={() => {
-            // find all videos and pause them
-            const videos = document.querySelectorAll('.yarl__slide video')
-            videos.forEach((video) => {
-              video.pause()
-            })
-            setLightboxActiveIndex(null)
-          }}
-          on={{
-            view: (data) => {
+          <div
+            className={clsx(
+              'mx-auto mt-2 rounded-2xl bg-white p-4 text-black',
+              'lg:p-6'
+            )}
+          >
+            {/* lg:grid-cols-1 lg:grid-cols-2 lg:grid-cols-3 */}
+            {filteredWorkItems.length > 0 && (
+              <div
+                className={clsx(
+                  'grid grid-cols-1 gap-4',
+                  filteredWorkItems.length >= 3
+                    ? 'lg:grid-cols-3'
+                    : `lg:grid-cols-${filteredWorkItems.length}`,
+                  isSocialLayout && 'mx-auto grid-cols-3 xl:grid-cols-6'
+                )}
+              >
+                {filteredWorkItems.map((workItem, index) => {
+                  return (
+                    <WorkItemTile
+                      workItem={workItem}
+                      key={index}
+                      aspectRatio={
+                        isSocialLayout
+                          ? `aspect-w-${workItem.videoWidthAspectRatio} aspect-h-${workItem.videoHeightAspectRatio}`
+                          : ''
+                      }
+                      onClick={
+                        isSocialLayout
+                          ? () => {
+                              setLightboxActiveIndex(index)
+                            }
+                          : undefined
+                      }
+                      typographyClassNameOverrides={
+                        isSocialLayout
+                          ? {
+                              clientName: clsx(
+                                'text-lg font-extrabold uppercase transition-opacity duration-300',
+                                'lg:text-2xl',
+                                'group-hover:opacity-0'
+                              ),
+                              title: clsx(
+                                'font-outline text-lg uppercase transition-opacity duration-300',
+                                'lg:text-2xl',
+                                'group-hover:opacity-0'
+                              ),
+                            }
+                          : undefined
+                      }
+                      showPlayOnHover={isSocialLayout}
+                    />
+                  )
+                })}
+              </div>
+            )}
+
+            {showWhiteContainer && (
+              <div className="text-center">
+                {currentCategory?.imageGallery &&
+                  currentCategory.imageGallery.length > 0 && (
+                    <ClientOnly>
+                      <ImageGallery images={currentCategory.imageGallery} />
+                    </ClientOnly>
+                  )}
+                {(currentCategory?.title ||
+                  currentCategory?.subtitle ||
+                  currentCategory?.body) && (
+                  <div className="mt-12">
+                    {currentCategory?.title && (
+                      <h2 className="text-3xl font-extrabold uppercase lg:text-3xl">
+                        {currentCategory.title}
+                      </h2>
+                    )}
+                    {currentCategory?.subtitle && (
+                      <h3 className="font-outline text-3xl uppercase lg:text-4xl">
+                        {currentCategory.subtitle}
+                      </h3>
+                    )}
+                    {currentCategory?.body && (
+                      <>
+                        <LittleBlackBar yMargin="my-6" maxWidth="max-w-xs" />
+                        <div className="mx-auto max-w-2xl py-1 text-center text-sm font-light uppercase">
+                          <PortableText value={currentCategory.body} />
+                        </div>
+                      </>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+          {workPage.workPageDescription && (
+            <div className="container mx-auto mt-12 px-12 text-center text-white">
+              {workPage.workPageDescription && (
+                <div className="prose prose-lg mx-auto max-w-lg border py-1 text-center">
+                  <PortableText value={workPage.workPageDescription} />
+                </div>
+              )}
+            </div>
+          )}
+          {/* {showWhiteContainer && (
+            
+          )} */}
+        </div>
+
+        {isSocialLayout && (
+          <Lightbox
+            open={lightboxActiveIndex !== null}
+            slides={lightboxSlides}
+            index={lightboxActiveIndex}
+            close={() => {
               // find all videos and pause them
               const videos = document.querySelectorAll('.yarl__slide video')
               videos.forEach((video) => {
                 video.pause()
               })
+              setLightboxActiveIndex(null)
+            }}
+            on={{
+              view: (data) => {
+                // find all videos and pause them
+                const videos = document.querySelectorAll('.yarl__slide video')
+                videos.forEach((video) => {
+                  video.pause()
+                })
 
-              setTimeout(() => {
-                const currentVideo = document.getElementById(
-                  `social-video-${data.index}`
+                setTimeout(() => {
+                  const currentVideo = document.getElementById(
+                    `social-video-${data.index}`
+                  )
+                  currentVideo?.play()
+                }, 500)
+              },
+            }}
+            render={{
+              slide: ({ slide }) => {
+                return (
+                  <SlideVideo
+                    slide={slide}
+                    isActive={slide.index === lightboxActiveIndex}
+                  />
                 )
-                currentVideo?.play()
-              }, 500)
-            },
-          }}
-          render={{
-            slide: ({ slide }) => {
-              return (
-                <SlideVideo
-                  slide={slide}
-                  isActive={slide.index === lightboxActiveIndex}
-                />
-              )
-            },
-          }}
-        />
-      )}
+              },
+            }}
+          />
+        )}
+      </div>
     </Layout>
   )
 }

--- a/web/components/work-item-tile.js
+++ b/web/components/work-item-tile.js
@@ -37,7 +37,7 @@ const WorkItemTile = ({
           'lg:hidden': index >= hideAfterCount,
         },
         aspectRatio ? aspectRatio : 'bpd-project-tile',
-        `relative text-white`,
+        `relative overflow-hidden rounded-xl text-white`,
         `flex flex-col items-center justify-center space-y-2 lg:space-y-0`,
         className
       )}

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/pages/documentary.js
+++ b/web/pages/documentary.js
@@ -165,7 +165,7 @@ const Documentary = ({ documentaryPage }) => {
                     .url()}
                   height={630}
                   width={410}
-                  className="mx-auto"
+                  className="mx-auto rounded-xl"
                 />
               </div>
               <div className="prose prose-lg prose-invert md:w-3/4">

--- a/web/pages/documentary.js
+++ b/web/pages/documentary.js
@@ -216,7 +216,7 @@ const Documentary = ({ documentaryPage }) => {
                     >
                       <div
                         className={clsx(
-                          'absolute inset-0 rounded-lg bg-linear-to-t from-black/100 via-black/30 to-black/0 opacity-50 transition-all duration-300',
+                          'absolute inset-0 rounded-lg bg-linear-to-t from-black via-black/30 to-black/0 opacity-50 transition-all duration-300',
                           'lg:from-transparent lg:via-transparent lg:to-transparent lg:opacity-0',
                           'group-hover:from-black/80 group-hover:via-black/80 group-hover:to-black/80 group-hover:opacity-100'
                         )}

--- a/web/pages/news/[slug].js
+++ b/web/pages/news/[slug].js
@@ -30,7 +30,7 @@ const NewsItem = ({ newsItem = {} }) => {
                   .crop('focalpoint')
                   .url()}
                 fill
-                className="object-cover"
+                className="rounded-xl object-cover"
               />
             </div>
           )}


### PR DESCRIPTION
## Summary
- Add `rounded-xl` to images that were missing it: moments gallery (desktop + mobile), news hero, documentary poster.
- Add `rounded-xl overflow-hidden` to `WorkItemTile` so the poster background and hover video are clipped to match other photo styling.
- Bump the work category grid from `mx-1 gap-1` to `mx-4 mt-2 gap-4` so the now-rounded tiles have breathing room.

## Test plan
- [ ] /work — tiles are rounded, grid has even spacing, hover video stays clipped inside the rounded shape.
- [ ] /moments — gallery photos are rounded on desktop and mobile.
- [ ] /news/[slug] — hero image is rounded.
- [ ] /documentary — poster image is rounded.
- [ ] Logos, icons, and treatment slide backgrounds remain unrounded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Applied rounded corners to images across galleries, news, and documentary pages.
  * Enhanced work item tiles with rounded corners and improved overflow handling.
  * Refined spacing and margins in work item category grid layout.

* **Chores**
  * Updated project ignore file and development environment typing reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->